### PR TITLE
Add ability to change Patchwork instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This extension integrates VSCode with [Patchwork](http://jk.ozlabs.org/projects/
 * Applying series or patches locally
 * Reading mail replies
 * Replying to emails directly from the IDE (using git send-email)
+
+The extension is set to use patchwork.kernel.org by default. You can change this to your preferred Patchwork instance in the extension's settings. Look for `patchwork.baseUrl`.

--- a/package.json
+++ b/package.json
@@ -114,6 +114,16 @@
           "group": "inline"
         }
       ]
+    },
+    "configuration": {
+      "title": "Patchwork",
+      "properties": {
+        "patchwork.baseUrl": {
+          "type": "string",
+          "default": "https://patchwork.kernel.org",
+          "description": "The full base URL (protocol included) for your desired Patchwork instance."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { gitAm } from "./utilities/gitAm";
 import * as vscode from "vscode";
 import { fetchAPIHTMLPage, getPersons, getProjects } from "./utilities/fetchAPIHTMLPage";
 import { SavedFiltersDataProvider } from "./tree-views/SavedFiltersDataProvider";
+import { onConfigurationUpdate } from "./utilities/config";
 
 export async function activate(context: ExtensionContext) {
   // Retrieve the list of projects and persons from cache if available
@@ -211,4 +212,6 @@ export async function activate(context: ExtensionContext) {
       }
     })
   );
+
+  context.subscriptions.push(onConfigurationUpdate);
 }

--- a/src/tree-views/SeriesDataProvider.ts
+++ b/src/tree-views/SeriesDataProvider.ts
@@ -3,6 +3,7 @@ import { Event, EventEmitter, TreeDataProvider, TreeItem, TreeItemCollapsibleSta
 import { PatchesService, CoverLetterService, SeriesService, Filter } from "../rest-api/Endpoints";
 import { Patch, Series } from "../rest-api/Types";
 import { gravatarUri } from "../utilities/gravatarUri";
+import { makeURL } from "../utilities/config";
 import * as vscode from "vscode";
 import { userAgent } from "../utilities/userAgent";
 
@@ -23,7 +24,7 @@ export class SeriesDataProvider implements TreeDataProvider<PossibleNode> {
   constructor(currentFilter: Filter, context: vscode.ExtensionContext) {
     this.forestInstance = forest.create({
       axiosSettings: {
-        baseURL: "https://patchwork.kernel.org/api/",
+        baseURL: makeURL("/api/"),
         headers: { 'User-Agent': userAgent(context) },
       },
     });

--- a/src/utilities/config.ts
+++ b/src/utilities/config.ts
@@ -1,0 +1,28 @@
+import { commands, window, workspace } from "vscode";
+
+const config = workspace.getConfiguration("patchwork");
+
+export function makeURL(path: string): string {
+    const baseUrl: string | undefined = config.get("baseUrl");
+
+    try {
+        return (new URL(path, baseUrl)).toString();
+    } catch(ex) {
+        throw new Error("An invalid base URL for Patchwork was provided. Check the extension configuration and reload");
+    }
+}
+
+export const onConfigurationUpdate = workspace.onDidChangeConfiguration(async e => {
+    if (e.affectsConfiguration("patchwork.baseUrl")) {
+        const action = "Reload Window";
+
+        const prompt = await window.showInformationMessage(
+            "You've updated the Patchwork URL, reload the window for the new configuration to take effect.",
+            action
+        );
+
+        if (prompt === action) {
+            commands.executeCommand("workbench.action.reloadWindow");
+        }
+    }
+});

--- a/src/utilities/fetchAPIHTMLPage.ts
+++ b/src/utilities/fetchAPIHTMLPage.ts
@@ -2,12 +2,13 @@ import axios from "axios";
 import * as jsdom from "jsdom";
 import { ExtensionContext } from "vscode";
 import { userAgent } from "./userAgent";
+import { makeURL } from "./config";
 
 export async function fetchAPIHTMLPage(context: ExtensionContext): Promise<jsdom.JSDOM> {
   // We can not retrieve Persons from the REST API without being connected. However...
   // Patchwork's Django REST web portal exposes it in its HTML. This lets us retrieve the list without requiring a connection.
   // This page also contains projects so while we are at it, scrap these too
-  const html = await axios.get("https://patchwork.kernel.org/api/patches/?msgid=0", {
+  const html = await axios.get(makeURL("/api/patches/?msgid=0"), {
     headers: { Accept: "text/html", 'User-Agent': userAgent(context) },
   });
 


### PR DESCRIPTION
Hi @FlorentRevest,

Thank you for your great extension! After noticing that it's only setup for kernel.org's patchwork instance, and after noticing the issue #1 that was already raised by others, I decided to make a small patch to allow the instance to be changed.

It's very basic and all it does is move the base URL to a VS code configuration setting. Just enough to allow the extension to work with any other instance.

Hope you'll give it a chance!

Thank you,
Luca