### PR TITLE
Fix tab switching when selecting patch or series

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,6 +91,9 @@ export async function activate(context: ExtensionContext) {
         });
       }
       panel.title = payload.name;
+
+      // Ensure the panel/tab is focused when a series/patch is selected
+      panel.reveal(panel.viewColumn ?? ViewColumn.Active, false);
     })
   );
 


### PR DESCRIPTION
When clicking on a patch series while another tab is in focus, the extension would update the panel content but not switch to that tab. Add panel.reveal() call to ensure the webview panel is brought to the foreground when a series or patch is selected.